### PR TITLE
Fixes debconf Error

### DIFF
--- a/mongod/Dockerfile
+++ b/mongod/Dockerfile
@@ -8,6 +8,8 @@ RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen
 #RUN dpkg-divert --local --rename --add /sbin/initctl
 #RUN ln -s /bin/true /sbin/initctl
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Install MongoDB
 RUN apt-get update
 RUN apt-get install mongodb-10gen

--- a/mongod/Dockerfile
+++ b/mongod/Dockerfile
@@ -11,12 +11,10 @@ RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install MongoDB
-RUN apt-get update
-RUN apt-get install mongodb-10gen
+RUN apt-get update && apt-get install -y mongodb-org
 
 # Create the MongoDB data directory
 RUN mkdir -p /data/db
 
 EXPOSE 27017
 ENTRYPOINT ["usr/bin/mongod"]
-


### PR DESCRIPTION
Adds ENV variable DEBIAN_FRONTEND as noninteractive so that the
following errors do not occur:
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin:
